### PR TITLE
Add Jest tests for utility functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,10 @@
     "prettier": "3.4.2",
     "prettier-plugin-tailwindcss": "0.6.9",
     "tailwindcss": "3.4.15",
-    "typescript": "5.7.2"
+    "typescript": "5.7.2",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.1",
+    "@types/jest": "29.5.11"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -76,5 +79,13 @@
   "overrides": {
     "react": "18.2.0",
     "react-dom": "18.2.0"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "roots": ["<rootDir>/tests"],
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1"
+    }
   }
 }

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -1,0 +1,32 @@
+import { cn, formatDate, formatCurrency } from '../../src/lib/utils/index';
+
+describe('cn', () => {
+  test('combines class names and ignores falsy values', () => {
+    expect(cn('foo', false && 'bar', null, undefined, 'baz')).toBe('foo baz')
+  })
+
+  test('merges tailwind classes', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+})
+
+describe('formatDate', () => {
+  test('formats Date instances', () => {
+    const date = new Date('2020-05-02')
+    expect(formatDate(date)).toBe('May 2, 2020')
+  })
+
+  test('formats ISO date strings', () => {
+    expect(formatDate('2021-12-25')).toBe('December 25, 2021')
+  })
+})
+
+describe('formatCurrency', () => {
+  test('formats USD by default', () => {
+    expect(formatCurrency(1234)).toBe('$1,234.00')
+  })
+
+  test('formats other currencies', () => {
+    expect(formatCurrency(500, 'EUR')).toBe('€500.00')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "allowUnusedLabels": false,
     "exactOptionalPropertyTypes": true,
     "noImplicitOverride": true,
-    "types": ["node"],
+      "types": ["node", "jest"],
     "plugins": [
       {
         "name": "next"

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,7 +7,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": false,
-    "types": ["node"],
+      "types": ["node", "jest"],
     "target": "ES2020",
     "lib": ["ES2020"],
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- add Jest unit tests covering `cn`, `formatDate`, and `formatCurrency`
- configure Jest with `ts-jest` and map `@` alias
- include Jest dev dependencies
- allow Jest types in TS configs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68413e585f788324a4d5258513561b1b